### PR TITLE
Update OkHttpClient timeout unit from second to millisecond

### DIFF
--- a/lib/src/main/java/be/teletask/onvif/OnvifExecutor.java
+++ b/lib/src/main/java/be/teletask/onvif/OnvifExecutor.java
@@ -45,9 +45,9 @@ public class OnvifExecutor {
         Map<String, CachingAuthenticator> authCache = new ConcurrentHashMap<>();
 
         client = new OkHttpClient.Builder()
-                .connectTimeout(10000, TimeUnit.SECONDS)
-                .writeTimeout(100, TimeUnit.SECONDS)
-                .readTimeout(10000, TimeUnit.SECONDS)
+                .connectTimeout(10000, TimeUnit.MILLISECONDS)
+                .writeTimeout(100, TimeUnit.MILLISECONDS)
+                .readTimeout(10000, TimeUnit.MILLISECONDS)
                 .authenticator(new CachingAuthenticatorDecorator(authenticator, authCache))
                 .addInterceptor(new AuthenticationCacheInterceptor(authCache))
                 .build();


### PR DESCRIPTION
I think current TimeUnit in OkHttpClient timeout setting is wrong.